### PR TITLE
PWG stuffs: allow displaying recent images outside the recent period

### DIFF
--- a/language/en_UK/plugin.lang.php
+++ b/language/en_UK/plugin.lang.php
@@ -106,6 +106,7 @@ $lang['module_name_mostvisited'] = 'Most visited';
 $lang['module_desc_mostvisited'] = 'Display x most visited pictures in the gallery or a category';
 
 $lang['stuffs_mv_nb_images'] = 'Maximum number of pictures to display';
+$lang['stuffs_mv_recent_period_only'] = 'Only display images from the recent period';
 $lang['stuffs_mv_category_display'] = 'Display on categories pages';
 $lang['stuffs_mv_all_cats'] = 'All categories';
 $lang['stuffs_mv_w_thumb'] = 'Only categories with thumbnails';

--- a/language/fr_FR/plugin.lang.php
+++ b/language/fr_FR/plugin.lang.php
@@ -106,6 +106,7 @@ $lang['module_name_mostvisited'] = 'Plus vues';
 $lang['module_desc_mostvisited'] = 'Affiche les x images les plus vues de la galerie ou de la catégorie';
 
 $lang['stuffs_mv_nb_images'] = 'Nombre maximum d\'images à afficher';
+$lang['stuffs_mv_recent_period_only'] = 'N\'afficher que les photos de la période récente';
 $lang['stuffs_mv_category_display'] = 'Affichage sur les pages des catégories';
 $lang['stuffs_mv_all_cats'] = 'Toutes les catégories';
 $lang['stuffs_mv_w_thumb'] = 'Catégories avec miniatures uniquement';

--- a/modules/Recent/config.inc.php
+++ b/modules/Recent/config.inc.php
@@ -5,6 +5,7 @@ if (!isset($datas))
 {
   $datas = array(
     'nb_images'     => 10,
+    'recent_period_only' => true,
     'cat_display'   => 'all',
     'cat_selection' => array(),
   );
@@ -15,6 +16,7 @@ if (isset($_POST['submit']))
 {
   $datas = array(
     'nb_images' => intval($_POST['nb_images']),
+    'recent_period_only' => !empty($_POST['recent_period_only']),
     'cat_display' => $_POST['cat_display'],
     'cat_selection' => @$_POST['cat_selection'],
     );
@@ -27,6 +29,7 @@ display_select_cat_wrapper($query,array(),'category_selection');
 
 $template->assign(array(
   'NB_IMAGES' => $datas['nb_images'],
+  'RECENT_PERIOD_ONLY' => $datas['recent_period_only'],
   'cat_display' => $datas['cat_display'],
   'category_selected' => $datas['cat_selection'],
   )

--- a/modules/Recent/config.tpl
+++ b/modules/Recent/config.tpl
@@ -5,6 +5,10 @@
 		<td align="right"><br>{'stuffs_mv_nb_images'|@translate} &nbsp;&nbsp;</td>
 		<td><br><input type="text" name="nb_images" size="3" maxlength="2" value="{$NB_IMAGES}"></td>
 	</tr>
+	<tr>
+		<td align="right"><br>{'stuffs_mv_recent_period_only'|@translate} &nbsp;&nbsp;</td>
+		<td><br><input type="checkbox" name="recent_period_only" {if $RECENT_PERIOD_ONLY}checked="checked"{/if}></td>
+	</tr>
 	<tr class="cat_options" style="display: none;">
 		<td align="right"><br>{'stuffs_mv_category_display'|@translate} &nbsp;&nbsp;</td>
 		<td><br>

--- a/modules/Recent/main.inc.php
+++ b/modules/Recent/main.inc.php
@@ -30,9 +30,16 @@ $query ='
 SELECT DISTINCT(i.id)
   FROM '.IMAGES_TABLE.' AS i
     INNER JOIN '.IMAGE_CATEGORY_TABLE.' AS ic ON i.id = ic.image_id
-    INNER JOIN '.CATEGORIES_TABLE.' AS c ON ic.category_id = c.id
-  WHERE i.date_available >= SUBDATE(
-      CURRENT_DATE,INTERVAL '.$user['recent_period'].' DAY)';
+    INNER JOIN '.CATEGORIES_TABLE.' AS c ON ic.category_id = c.id';
+
+if (!isset($datas['recent_period_only']) or
+    $datas['recent_period_only'])
+{
+  $query .= '
+        WHERE i.date_available >= SUBDATE(
+      CURRENT_DATE,INTERVAL '.$user['recent_period'].' DAY)
+  ';
+}
 
 if (isset($page['category']))
 {


### PR DESCRIPTION
The "Recent pictures" was previously taking only pictures from the recent
period. For example, when no pictures were recently added, the block was
empty.

This patch adds a "Only display images from the recent period"
configuration checkbox (ticked by default to preserve the original
behavior). Unchecking it allows taking "the N most recent pictures",
regardless of the recent period. This way, the block will never be empty
(except if the gallery is actually empty).
