### PR TITLE
Update class.inc.php

### DIFF
--- a/class.inc.php
+++ b/class.inc.php
@@ -10,7 +10,7 @@ class stuffs
   var $pos = 'begin';
   var $prefixe = 'PLUGIN_INDEX_CONTENT_';
 
-  function stuffs()
+  function __construct()
   {
     global $page, $template;
 


### PR DESCRIPTION
PHP7 compatibility - constructor must not have the same name as the class

PWG_Stuffs raise the following E_DEPRECATED warning

Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; stuffs has a deprecated constructor in /Piwigo/plugins/PWG_Stuffs/class.inc.php on line 5

I think, `function __construct() {}`  should be used instead of  `function stuffs() {}` in class.inc.php line 13