### PR TITLE
Quote `groups` column name

### DIFF
--- a/admin/add_module.inc.php
+++ b/admin/add_module.inc.php
@@ -51,7 +51,7 @@ SET name ="' . $module_name . '",
     descr=' . $desc . ',
     datas=' . $sav_datas . ',
     users=' . $users . ',
-    groups=' . $groups . ',
+    `groups`=' . $groups . ',
     level=' . $level . ',
     show_title=' . $show_title .',
     on_home=' . $on_home .',
@@ -73,7 +73,7 @@ WHERE id = ' . $_GET['edit'] . ';');
         list($pos) = pwg_db_fetch_row(pwg_query($query));
 
         $query = '
-INSERT INTO ' . STUFFS_TABLE . ' ( id, pos, name, descr, path, datas, users, groups, level, show_title, on_home, on_root, on_cats, on_picture, id_line, width )
+INSERT INTO ' . STUFFS_TABLE . ' ( id, pos, name, descr, path, datas, users, `groups`, level, show_title, on_home, on_root, on_cats, on_picture, id_line, width )
 VALUES (' . $next_element_id . ' ,
   ' . $pos . ',
   "' . $module_name . '",

--- a/admin/config.inc.php
+++ b/admin/config.inc.php
@@ -20,7 +20,7 @@ if (isset($_POST['submit']))
   }
   if ($conf['Stuffs']['group_perm'] and !isset($_POST['group_perm']))
   {
-    pwg_query('UPDATE '.STUFFS_TABLE.' SET groups = NULL;');
+    pwg_query('UPDATE '.STUFFS_TABLE.' SET `groups` = NULL;');
   }
   if ($conf['Stuffs']['level_perm'] and !isset($_POST['level_perm']))
   {

--- a/admin/upgrade.inc.php
+++ b/admin/upgrade.inc.php
@@ -15,7 +15,7 @@ MODIFY COLUMN type VARCHAR(255) CHARACTER SET utf8 NOT NULL,
 MODIFY COLUMN params VARCHAR(255) CHARACTER SET utf8 default NULL,
 MODIFY COLUMN datas LONGTEXT CHARACTER SET utf8 default NULL,
 MODIFY COLUMN users VARCHAR(255) CHARACTER SET utf8 default NULL,
-MODIFY COLUMN groups VARCHAR(255) CHARACTER SET utf8 default NULL,
+MODIFY COLUMN `groups` VARCHAR(255) CHARACTER SET utf8 default NULL,
 DEFAULT CHARACTER SET utf8,
 ADD show_title ENUM(\'true\',\'false\') NOT NULL,
 ADD on_home ENUM(\'true\',\'false\') NOT NULL,
@@ -157,7 +157,7 @@ WHERE users <> "guest,generic,normal,admin,webmaster"
 
   $query = 'SELECT id
 FROM '.STUFFS_TABLE.'
-WHERE groups IS NOT NULL
+WHERE `groups` IS NOT NULL
 ;';
   $ids = array_from_query($query, 'id');
   $conf['Stuffs']['group_perm'] = !empty($ids);

--- a/class.inc.php
+++ b/class.inc.php
@@ -57,12 +57,12 @@ class stuffs
     if (!isset($page['stuffs_section'])) return;
 
     $query = '
-SELECT DISTINCT id, name, path, datas, groups, show_title, id_line, width
+SELECT DISTINCT id, name, path, datas, `groups`, show_title, id_line, width
 FROM ' . STUFFS_TABLE . '
 LEFT JOIN ' . USER_GROUP_TABLE . '
   ON user_id = '.$user['id'].'
 WHERE (users IS NULL OR users LIKE "%' . $user['status'] . '%")
-  AND (groups IS NULL OR groups REGEXP CONCAT("(^|,)",group_id,"(,|$)"))
+  AND (`groups` IS NULL OR `groups` REGEXP CONCAT("(^|,)",group_id,"(,|$)"))
   AND level <= '.$user['level'].'
   AND '.$page['stuffs_section'].' = "true"
 ORDER BY pos ASC


### PR DESCRIPTION
Since MySQL 8 groups is a reserved keyword, quote it in backticks
on every use.