### PR TITLE
Better URL for thumbnails on Recent module

### DIFF
--- a/modules/Recent/main.inc.php
+++ b/modules/Recent/main.inc.php
@@ -57,7 +57,7 @@ $query .= '
 $page['items'] = array_from_query($query, 'id');
 $page['start'] = 0;
 $page['nb_image_page'] = $datas['nb_images'];
-$page['section'] = 'category';
+$page['section'] = 'recent_pics';
 
 $tpl_thumbnails_var = array();
 $pwg_stuffs_tpl_thumbnails_var = & $tpl_thumbnails_var;


### PR DESCRIPTION
I've added the recent module to the home page of my
site. The picture thumbnails get an URL like this:

http://localhost/photolib/picture.php?/35851/category

When followed this lead to a blank page.

With this change the generated URL looks like this:

http://localhost/photolib/picture.php?/35851/recent_pics

which takes the user to the recent photos page - a better
user experience.

tjk :)